### PR TITLE
Implement WRGSBASE decode

### DIFF
--- a/src/arch/x86/isa/decoder/two_byte_opcodes.isa
+++ b/src/arch/x86/isa/decoder/two_byte_opcodes.isa
@@ -823,6 +823,9 @@
             //0x6: group15();
             0x6: decode MODRM_MOD {
                 0x3: decode MODRM_REG {
+                    decode LEGACY_REP {
+                        0x3: WRGSBASE_R(Gv);
+                    }
                     0x5: BasicOperate::LFENCE({{/*Nothing*/}},
                                               IsReadBarrier, IsSerializeAfter);
                     0x6: BasicOperate::MFENCE({{/*Nothing*/}},

--- a/src/arch/x86/isa/decoder/two_byte_opcodes.isa
+++ b/src/arch/x86/isa/decoder/two_byte_opcodes.isa
@@ -822,17 +822,17 @@
             0x5: Inst::SHRD(Ev,Gv);
             //0x6: group15();
             0x6: decode MODRM_MOD {
-                0x3: decode MODRM_REG {
-                    decode LEGACY_REP {
-                        0x3: WRGSBASE_R(Gv);
+                0x3: decode LEGACY_REP {
+                    0x1: Inst::WRGSBASE(Rv);
+                    0x0: decode MODRM_REG {
+                        0x5: BasicOperate::LFENCE({{/*Nothing*/}},
+                                                  IsReadBarrier, IsSerializeAfter);
+                        0x6: BasicOperate::MFENCE({{/*Nothing*/}},
+                                                  IsReadBarrier, IsWriteBarrier);
+                        0x7: BasicOperate::SFENCE({{/*Nothing*/}},
+                                                  IsWriteBarrier);
+                        default: Inst::UD2();
                     }
-                    0x5: BasicOperate::LFENCE({{/*Nothing*/}},
-                                              IsReadBarrier, IsSerializeAfter);
-                    0x6: BasicOperate::MFENCE({{/*Nothing*/}},
-                                              IsReadBarrier, IsWriteBarrier);
-                    0x7: BasicOperate::SFENCE({{/*Nothing*/}},
-                                              IsWriteBarrier);
-                    default: Inst::UD2();
                 }
                 default: decode MODRM_REG {
                     0x0: decode OPSIZE {

--- a/src/arch/x86/isa/insts/system/segmentation.py
+++ b/src/arch/x86/isa/insts/system/segmentation.py
@@ -340,4 +340,9 @@ def macroop SWAPGS
     wrbase gs, t1, dataSize=8
     wrval kernel_gs_base, t2, dataSize=8
 };
+
+def macroop WRGSBASE_R
+{
+    panic "WRGSBASE microcode not implemented";
+};
 """

--- a/src/arch/x86/isa/insts/system/segmentation.py
+++ b/src/arch/x86/isa/insts/system/segmentation.py
@@ -343,6 +343,7 @@ def macroop SWAPGS
 
 def macroop WRGSBASE_R
 {
-    panic "WRGSBASE microcode not implemented";
+    wrbase gs, reg
+    wrval gs_eff_base, reg
 };
 """

--- a/src/arch/x86/isa/microasm.isa
+++ b/src/arch/x86/isa/microasm.isa
@@ -180,7 +180,8 @@ let {{
 
     for reg in (('sysenter_cs', 'SysenterCs'), ('sysenter_esp', 'SysenterEsp'),
                 ('sysenter_eip', 'SysenterEip'), 'star', 'lstar', 'cstar',
-                ('sf_mask', 'SfMask'), ('kernel_gs_base', 'KernelGsBase')):
+                ('sf_mask', 'SfMask'), ('kernel_gs_base', 'KernelGsBase'),
+                ('gs_eff_base', 'GsEffBase')):
         if isinstance(reg, tuple):
             assembler.symbols[reg[0]] = ctrlRegIdx(f"misc_reg::{reg[1]}")
         else:


### PR DESCRIPTION
## Summary
- add WRGSBASE decode in two_byte_opcodes
- stub macro implementation for WRGSBASE_R

## Testing
- `pre-commit run --files src/arch/x86/isa/decoder/two_byte_opcodes.isa src/arch/x86/isa/insts/system/segmentation.py`

------
https://chatgpt.com/codex/tasks/task_e_6848c3b122148333a9e68a68ff16a45c